### PR TITLE
Cleaning state pollution in `si_app`

### DIFF
--- a/test/test_plugin_mysql_hdfs.py
+++ b/test/test_plugin_mysql_hdfs.py
@@ -83,6 +83,8 @@ hdfs_ds_dict = {
 
 
 def test_plugin_hdfs_add():
+    si_app.delete_data_soruce(hdfs_ds_dict)
+    si_app.data_source_dict.clear()
     dict1 = si_app.get_data_source_dict(ds_name=hdfs_ds_dict['ds_name'])
     assert dict1 is None
 

--- a/test/test_plugin_mysql_hdfs.py
+++ b/test/test_plugin_mysql_hdfs.py
@@ -51,6 +51,8 @@ def test_plugin_loading(resource_a_setup):
 
 
 def test_plugin_mysql_add(resource_a_setup):
+    si_app.delete_data_soruce(ds_dict)
+    si_app.data_source_dict.clear()
     dict1 = si_app.get_data_source_dict(ds_name=ds_dict['ds_name'])
     assert dict1 is None
 


### PR DESCRIPTION

This PR aims to improve test reliability of test `test_plugin_hdfs_add` by cleaning state pollution in `si_app` by deleting data source and clearing `data_source_dict`

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 test/test_plugin_mysql_hdfs.py::test_plugin_hdfs_add`:

```
    def test_plugin_hdfs_add():
        si_app.delete_data_soruce(hdfs_ds_dict)
        dict1 = si_app.get_data_source_dict(ds_name=hdfs_ds_dict['ds_name'])
>       assert dict1 is None
E       AssertionError: assert {'_sa_instance_state': <sqlalchemy.orm.state.InstanceState object at 0x7fd7bfbe38b0>, 'created_date': datetime.datetime(2021, 8, 25, 2, 14, 1), 'ds_desc': 'created by unittest of hdfsindex', 'ds_name': 'hdfs1', ...} is None
```

Such failure occurs while running on `test_plugin_mysql_add`, and can be fixed in the same way.

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
