### PR TITLE
Removing state pollution in `resource_a_setup`

### DIFF
--- a/test/test_plugin_mysql_hdfs.py
+++ b/test/test_plugin_mysql_hdfs.py
@@ -10,7 +10,7 @@ from schemaindex.app.schemaindexapp import si_app
 from schemaindex.app.pluginmanager import si_pm
 import os
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='function')
 def resource_a_setup(request):
     print('\nDoing setup by putting init file')
     db_file_path = cfg['database']['sqlite_file']


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_plugin_loading` by removing state pollution in `resource_a_setup` by altering `pytest.fixture` scope to `function`

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 test/test_plugin_mysql_hdfs.py::test_plugin_loading`:

```
    def test_plugin_loading(resource_a_setup):
        list1 = si_app.get_plugin_name_list()
        print(list1)
>       assert len(list1) == 0
E       AssertionError: assert 6 == 0
E        +  where 6 = len(['mysql', 'hdfsindex', 'oracle', 'simplehdfsindex', 'sqlalchemy', 'MS_SQL_Server'])
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
